### PR TITLE
Fix retrieval of locale answers

### DIFF
--- a/src/MavenUniqueKey.php
+++ b/src/MavenUniqueKey.php
@@ -86,13 +86,8 @@ class MavenUniqueKey extends Model
     public function getFaq($locale) {
 
         $faqs = $this->faqs;
-
-        return $faqs->first(function($key, $faq) use($locale){
-
-            return $faq->locale == $locale;
-
-        });
-
+        return $faqs->firstWhere('locale', $locale);
+        
     }
 
     public function getQuestion($locale) {


### PR DESCRIPTION
Getting localized answers is not possible since getFaq() does not return the correct value. This can be fixed (and the method can be simplified) by these changes.